### PR TITLE
Uses string as entity id type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# Spinit.CosmosDb
+Spinit.CosmosDb
+===============
+
 Lightweight CosmosDb wrapper
+
+
+Install
+-------
+
+Package Manager:
+
+    PM> Install-Package Spinit.CosmosDb
+
+.NET CLI:
+
+    > dotnet add package Spinit.CosmosDb
+
+Usage
+-----
+
+### Define a database model:
+
+```
+public class MyEntity : ICosmosEntity
+{
+    public string Id { get; set; }
+    public string Title { get; set; }
+    public string Description { get; set; }
+}
+
+[DatabaseId("MyDatabase")] // name of the cosmos database, required
+public class MyDatabase : CosmosDatabase
+{
+    public MyDatabase(DatabaseOptions<MyDatabase> options)
+        : base(options)
+    { }
+
+    [CollectionId("MyEntities")] // name of the cosmos collection, required
+    public ICosmosDbCollection<MyEntity> MyEntities { get; private set; }
+}
+```
+
+### Add to services (IoC):
+
+```
+var myConnectionString = configuration.GetConnectionString("CosmosDb");
+
+services
+    ...
+    // This will register the database type and all it's collections
+    .AddCosmosDatabase<MyDatabase>(options => options.UseConnectionString(myConnectionString))
+    ...
+    ;
+```
+
+### Inject and use:
+
+```
+public class MyController : ControllerBase
+{
+    private readonly ICosmosDbCollection<MyEntity> _collection;
+
+    public MyController(ICosmosDbCollection<MyEntity> collection)
+    {
+        _collection = collection;
+    }
+
+    [HttpGet]
+    public Task<SearchResponse<MyEntity>> List(string query)
+    {
+        var searchRequest = new SearchRequest<MyEntity>
+        {
+            Query = query
+        };
+        return _collection.SearchAsync(searchRequest);
+    }
+
+    [HttpGet("{id}")]
+    public Task<MyEntity> Get(string id)
+    {
+        return _collection.GetAsync(id);
+    }
+
+    [HttpPost]
+    public Task Upsert(MyEntity input)
+    {
+        return _collection.UpsertAsync(input);
+    }
+}
+```

--- a/Spinit.CosmosDb.UnitTests/CosmosDatabaseTests.cs
+++ b/Spinit.CosmosDb.UnitTests/CosmosDatabaseTests.cs
@@ -39,7 +39,7 @@ namespace Spinit.CosmosDb.UnitTests
 
             public class TestEntity : ICosmosEntity
             {
-                public Guid Id { get; set; }
+                public string Id { get; set; }
                 public string Title { get; set; }
             }
         }

--- a/Spinit.CosmosDb.UnitTests/DbEntryTests.cs
+++ b/Spinit.CosmosDb.UnitTests/DbEntryTests.cs
@@ -15,7 +15,7 @@ namespace Spinit.CosmosDb.UnitTests
             {
                 _entity = new TestEntity
                 {
-                    Id = Guid.NewGuid(),
+                    Id = Guid.NewGuid().ToString(),
                     Name = "Test Entity"
                 };
                 _dbEntry = new DbEntry<TestEntity>(_entity);
@@ -24,7 +24,7 @@ namespace Spinit.CosmosDb.UnitTests
             [Fact]
             public void IdShouldBeSet()
             {
-                Assert.NotEqual(Guid.Empty, _dbEntry.Id);
+                Assert.NotEmpty(_dbEntry.Id);
             }
 
             [Fact]
@@ -71,7 +71,7 @@ namespace Spinit.CosmosDb.UnitTests
 
             public class TestEntity : ICosmosEntity
             {
-                public Guid Id { get; set; }
+                public string Id { get; set; }
                 public string Name { get; set; }
             }
         }

--- a/Spinit.CosmosDb.UnitTests/EntityExtensionsTests.cs
+++ b/Spinit.CosmosDb.UnitTests/EntityExtensionsTests.cs
@@ -58,7 +58,7 @@ namespace Spinit.CosmosDb.UnitTests
 
             private class TestEntity : ICosmosEntity
             {
-                public Guid Id { get; set; }
+                public string Id { get; set; }
                 public string StringProp { get; set; }
                 public int IntProp { get; set; }
                 public bool BoolProp { get; set; }
@@ -74,7 +74,7 @@ namespace Spinit.CosmosDb.UnitTests
             {
                 var entity = new TestEntity
                 {
-                    Id = Guid.NewGuid(),
+                    Id = Guid.NewGuid().ToString(),
                     Name = "Name",
                     Description = "Description"
                 };

--- a/Spinit.CosmosDb.UnitTests/Helpers/TestEntity.cs
+++ b/Spinit.CosmosDb.UnitTests/Helpers/TestEntity.cs
@@ -5,7 +5,7 @@ namespace Spinit.CosmosDb.UnitTests.Helpers
 {
     public class TestEntity : ICosmosEntity
     {
-        public Guid Id { get; set; }
+        public string Id { get; set; }
 
         public string Name { get; set; }
 

--- a/Spinit.CosmosDb/CosmosDatabase.cs
+++ b/Spinit.CosmosDb/CosmosDatabase.cs
@@ -20,7 +20,8 @@ namespace Spinit.CosmosDb
         internal static ConnectionPolicy CreateConnectionPolicy(IDatabaseOptions options)
         {
             var connectionPolicy = new ConnectionPolicy();
-            connectionPolicy.PreferredLocations.Add(options.PreferredLocation);
+            if (!string.IsNullOrEmpty(options.PreferredLocation))
+                connectionPolicy.PreferredLocations.Add(options.PreferredLocation);
             return connectionPolicy;
         }
 
@@ -34,7 +35,7 @@ namespace Spinit.CosmosDb
                 if (string.IsNullOrEmpty(databaseId))
                     throw new Exception($"No valid DatabaseId attribute found on type {GetType().Name}");
 
-                var collectionId = collectionProperty.GetCustomAttribute<CollectionIdAttribute>()?.CollectionId; 
+                var collectionId = collectionProperty.GetCustomAttribute<CollectionIdAttribute>()?.CollectionId;
                 if (string.IsNullOrEmpty(collectionId))
                     throw new Exception($"No valid CollectionId attribute found on property {collectionProperty.Name} on type {GetType().Name}");
 

--- a/Spinit.CosmosDb/CosmosServiceCollectionExtensions.cs
+++ b/Spinit.CosmosDb/CosmosServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 
+// TODO: Move to Microsoft.Extensions.DependencyInjection namespace?
 namespace Spinit.CosmosDb
 {
     public static class CosmosServiceCollectionExtensions
@@ -28,7 +29,7 @@ namespace Spinit.CosmosDb
            where TDatabase : CosmosDatabase
         {
             serviceCollection
-                .AddSingleton<DatabaseOptions<TDatabase>>(sp => 
+                .AddSingleton<DatabaseOptions<TDatabase>>(sp =>
                 {
                     var optionsBuilder = new DatabaseOptionsBuilder<TDatabase>();
                     options(optionsBuilder);
@@ -45,6 +46,6 @@ namespace Spinit.CosmosDb
                 });
             }
             return serviceCollection;
-        }        
+        }
     }
 }

--- a/Spinit.CosmosDb/DatabaseOptionsBuilder.cs
+++ b/Spinit.CosmosDb/DatabaseOptionsBuilder.cs
@@ -21,11 +21,15 @@ namespace Spinit.CosmosDb
                 ConnectionString = connectionString
             };
 
+            var preferredLocation = connectionStringBuilder.ContainsKey("PreferredLocation")
+                ? connectionStringBuilder["PreferredLocation"].ToString()
+                : null;
+
             Options = new DatabaseOptions<TDatabase>
             {
                 Endpoint = connectionStringBuilder["AccountEndpoint"].ToString(),
                 Key = connectionStringBuilder["AccountKey"].ToString(),
-                PreferredLocation = connectionStringBuilder["PreferredLocation"].ToString()
+                PreferredLocation = preferredLocation
             };
             return this;
         }

--- a/Spinit.CosmosDb/DbEntry.cs
+++ b/Spinit.CosmosDb/DbEntry.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Spinit.CosmosDb
-{    
+{
     internal class DbEntry<TEntity> : ICosmosEntity
         where TEntity : class, ICosmosEntity
     {
@@ -14,12 +13,12 @@ namespace Spinit.CosmosDb
         {
             Id = entity.Id;
             Original = entity;
-            Normalized = entity.CreateNormalized(); 
+            Normalized = entity.CreateNormalized();
             All = TermAnalyzer.Analyze(entity.GetAllTextFieldValues());
         }
 
         [JsonProperty(PropertyName = "id")]
-        public Guid Id { get; set; }
+        public string Id { get; set; }
 
         public TEntity Original { get; set; }
 

--- a/Spinit.CosmosDb/EntityExtensions.cs
+++ b/Spinit.CosmosDb/EntityExtensions.cs
@@ -9,12 +9,15 @@ namespace Spinit.CosmosDb
         internal static TEntity CreateNormalized<TEntity>(this TEntity entity)
             where TEntity : ICosmosEntity
         {
-            return JsonConvert.DeserializeObject<TEntity>(JsonConvert.SerializeObject(entity).ToLowerInvariant());
+            var normalized = JsonConvert.DeserializeObject<TEntity>(JsonConvert.SerializeObject(entity).ToLowerInvariant());
+            // restore original id
+            normalized.Id = entity.Id;
+            return normalized;
         }
 
         internal static IEnumerable<string> GetAllTextFieldValues(this ICosmosEntity entity)
         {
-            var stringProperties = entity.GetType().GetProperties().Where(x => x.PropertyType == typeof(string));
+            var stringProperties = entity.GetType().GetProperties().Where(x => x.PropertyType == typeof(string) && x.Name != nameof(ICosmosEntity.Id));
             return stringProperties.Select(x => x.GetValue(entity)?.ToString()).Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
         }
     }

--- a/Spinit.CosmosDb/ICosmosDbCollection.cs
+++ b/Spinit.CosmosDb/ICosmosDbCollection.cs
@@ -1,17 +1,20 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Spinit.CosmosDb
 {
     public interface ICosmosDbCollection<T>
         where T : class, ICosmosEntity
     {
-        Task<T> GetAsync(Guid id);
+        Task<T> GetAsync(string id);
+        Task<TProjection> GetAsync<TProjection>(string id)
+            where TProjection : class, ICosmosEntity;
         Task UpsertAsync(T document);
 
         // TODO: Only for C# 8
         //Task DeleteAsync(T document) => DeleteAsync(document.Id);
-        Task DeleteAsync(Guid id);
+        Task DeleteAsync(string id);
         Task<SearchResponse<T>> SearchAsync(ISearchRequest<T> request);
+        Task<SearchResponse<TProjection>> SearchAsync<TProjection>(ISearchRequest<T> request)
+            where TProjection : class, ICosmosEntity;
     }
 }

--- a/Spinit.CosmosDb/ICosmosEntity.cs
+++ b/Spinit.CosmosDb/ICosmosEntity.cs
@@ -1,9 +1,7 @@
-﻿using System;
-
-namespace Spinit.CosmosDb
+﻿namespace Spinit.CosmosDb
 {
     public interface ICosmosEntity
     {
-        Guid Id { get; set; }
+        string Id { get; set; }
     }
 }

--- a/Spinit.CosmosDb/SearchRequest.cs
+++ b/Spinit.CosmosDb/SearchRequest.cs
@@ -9,6 +9,10 @@ namespace Spinit.CosmosDb
         string Query { get; }
 
         int? PageSize { get; }
+        /// <summary>
+        /// Should <see cref="SearchResponse{T}.TotalCount"/> be calculated. This is currently a resource heavy operation, use sparingly.
+        /// </summary>
+        bool IncludeTotalCount { get; }
         string ContinuationToken { get; }
 
         Expression<Func<T, bool>> Filter { get; }
@@ -23,6 +27,10 @@ namespace Spinit.CosmosDb
         public virtual string Query { get; set; }
 
         public virtual int? PageSize { get; set; } = 20;
+        /// <summary>
+        /// Should <see cref="SearchResponse{T}.TotalCount"/> be calculated. This is currently a resource heavy operation, use sparingly.
+        /// </summary>
+        public virtual bool IncludeTotalCount { get; set; } = false;
         public virtual string ContinuationToken { get; set; }
 
         public virtual Expression<Func<T, bool>> Filter { get; set; }
@@ -38,6 +46,7 @@ namespace Spinit.CosmosDb
         {
             target.Query = source.Query;
             target.PageSize = source.PageSize;
+            target.IncludeTotalCount = source.IncludeTotalCount;
             target.ContinuationToken = source.ContinuationToken;
             target.Filter = source.Filter;
             target.SortBy = source.SortBy;

--- a/Spinit.CosmosDb/SearchResponse.cs
+++ b/Spinit.CosmosDb/SearchResponse.cs
@@ -6,5 +6,9 @@ namespace Spinit.CosmosDb
     {
         public string ContinuationToken { get; set; }
         public IEnumerable<T> Documents { get; set; }
+        /// <summary>
+        /// Total record count, only calculated if <see cref="ISearchRequest{T}.IncludeTotalCount"/> is set
+        /// </summary>
+        public int? TotalCount { get; set; }
     }
 }

--- a/Spinit.CosmosDb/Spinit.CosmosDb.csproj
+++ b/Spinit.CosmosDb/Spinit.CosmosDb.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>0.0.1</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.0.2</Version>
     <Authors>Spinit AB</Authors>
     <Description>Lightweigt CosmosDb wrapper</Description>
     <Copyright>Spinit AB</Copyright>
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a breaking change: use string as entity id type

Changes:
 * uses string as entity id type
 * projection support, needs documentation
 * targets netstandard2.0
 * updates nuget packages used
 * bug fixes
 * documentation improved