### PR TITLE
DateTimeParse handling

### DIFF
--- a/Spinit.CosmosDb.FunctionalTests/DateTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/DateTests.cs
@@ -27,14 +27,14 @@ namespace Spinit.CosmosDb.FunctionalTests
                     _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task ValueShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
                     Assert.Equal(_input.DateTime, output.DateTime);
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task KindShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
@@ -61,14 +61,14 @@ namespace Spinit.CosmosDb.FunctionalTests
                     _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task ValueShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
                     Assert.Equal(_input.DateTime, output.DateTime);
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task KindShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
@@ -98,14 +98,14 @@ namespace Spinit.CosmosDb.FunctionalTests
                     _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task ValueShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
                     Assert.Equal(_input.DateTimeOffset, output.DateTimeOffset);
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task OffsetShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
@@ -132,14 +132,14 @@ namespace Spinit.CosmosDb.FunctionalTests
                     _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task ValueShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
                     Assert.Equal(_input.DateTimeOffset, output.DateTimeOffset);
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task OffsetShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
@@ -168,14 +168,14 @@ namespace Spinit.CosmosDb.FunctionalTests
                     _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task ValueShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);
                     Assert.Equal(_input.DateTimeOffset, output.DateTimeOffset);
                 }
 
-                [Fact]
+                [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
                 public async Task OffsetShouldBePreserved()
                 {
                     var output = await _database.TestEntities.GetAsync(_input.Id);

--- a/Spinit.CosmosDb.FunctionalTests/DateTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/DateTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Spinit.CosmosDb.FunctionalTests
+{
+    public class DateTests
+    {
+        public class WhenUsingDateTime
+        {
+            [Collection(nameof(TestDatabaseCollection))]
+            public class Utc
+            {
+                private readonly TestDatabase _database;
+                private readonly TestEntity _input;
+
+                public Utc(TestDatabase database)
+                {
+                    _database = database;
+                    var utcNow = DateTime.UtcNow;
+                    _input = new TestEntity
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        DateTime = utcNow
+                    };
+
+                    _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
+                }
+
+                [Fact]
+                public async Task ValueShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTime, output.DateTime);
+                }
+
+                [Fact]
+                public async Task KindShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTime.Kind, output.DateTime.Kind);
+                }
+            }
+
+            [Collection(nameof(TestDatabaseCollection))]
+            public class Local
+            {
+                private readonly TestDatabase _database;
+                private readonly TestEntity _input;
+
+                public Local(TestDatabase database)
+                {
+                    _database = database;
+                    var now = DateTime.Now;
+                    _input = new TestEntity
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        DateTime = now
+                    };
+
+                    _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
+                }
+
+                [Fact]
+                public async Task ValueShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTime, output.DateTime);
+                }
+
+                [Fact]
+                public async Task KindShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTime.Kind, output.DateTime.Kind);
+                }
+            }
+        }
+
+        public class WhenUsingDateTimeOffset
+        {
+            [Collection(nameof(TestDatabaseCollection))]
+            public class Utc
+            {
+                private readonly TestDatabase _database;
+                private readonly TestEntity _input;
+
+                public Utc(TestDatabase database)
+                {
+                    _database = database;
+                    var utcNow = DateTimeOffset.UtcNow;
+                    _input = new TestEntity
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        DateTimeOffset = utcNow
+                    };
+
+                    _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
+                }
+
+                [Fact]
+                public async Task ValueShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTimeOffset, output.DateTimeOffset);
+                }
+
+                [Fact]
+                public async Task OffsetShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTimeOffset.Offset, output.DateTimeOffset.Offset);
+                }
+            }
+
+            [Collection(nameof(TestDatabaseCollection))]
+            public class Local
+            {
+                private readonly TestDatabase _database;
+                private readonly TestEntity _input;
+
+                public Local(TestDatabase database)
+                {
+                    _database = database;
+                    var now = DateTimeOffset.Now;
+                    _input = new TestEntity
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        DateTimeOffset = now
+                    };
+
+                    _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
+                }
+
+                [Fact]
+                public async Task ValueShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTimeOffset, output.DateTimeOffset);
+                }
+
+                [Fact]
+                public async Task OffsetShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTimeOffset.Offset, output.DateTimeOffset.Offset);
+                }
+            }
+
+            [Collection(nameof(TestDatabaseCollection))]
+            public class PacificTimeZone
+            {
+                private readonly TestDatabase _database;
+                private readonly TestEntity _input;
+
+                public PacificTimeZone(TestDatabase database)
+                {
+                    _database = database;
+                    var offset = TimeSpan.FromHours(8);
+                    var dateTimeNow = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
+                    var now = new DateTimeOffset(dateTimeNow, offset);
+                    _input = new TestEntity
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        DateTimeOffset = now
+                    };
+
+                    _database.TestEntities.UpsertAsync(_input).GetAwaiter().GetResult();
+                }
+
+                [Fact]
+                public async Task ValueShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTimeOffset, output.DateTimeOffset);
+                }
+
+                [Fact]
+                public async Task OffsetShouldBePreserved()
+                {
+                    var output = await _database.TestEntities.GetAsync(_input.Id);
+                    Assert.Equal(_input.DateTimeOffset.Offset, output.DateTimeOffset.Offset);
+                }
+            }
+        }
+
+        [CollectionDefinition(nameof(TestDatabaseCollection))]
+        public class TestDatabaseCollection : ICollectionFixture<TestDatabase> { }
+
+        public class TestDatabase : CosmosDatabase, IDisposable
+        {
+            public TestDatabase()
+                : base(new DatabaseOptionsBuilder<TestDatabase>().UseConnectionString(GenerateConnectionString()).Options)
+            {
+                if (FunctionTestsConfiguration.Enabled)
+                    Operations.CreateIfNotExistsAsync().GetAwaiter().GetResult();
+            }
+
+            private static string GenerateConnectionString()
+            {
+                var databaseId = $"db-{Guid.NewGuid().ToString("N")}";
+                return $"{FunctionTestsConfiguration.CosmosDbConnectionString};DatabaseId={databaseId}";
+            }
+
+            public void Dispose()
+            {
+                if (FunctionTestsConfiguration.Enabled)
+                    Operations.DeleteAsync().GetAwaiter().GetResult();
+            }
+
+            public ICosmosDbCollection<TestEntity> TestEntities { get; set; }
+        }
+
+        public class TestEntity : ICosmosEntity
+        {
+            public string Id { get; set; }
+            public DateTime DateTime { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+        }
+    }
+}

--- a/Spinit.CosmosDb.UnitTests/Internals/DateSerializingTests.cs
+++ b/Spinit.CosmosDb.UnitTests/Internals/DateSerializingTests.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Spinit.CosmosDb.UnitTests.Internals
+{
+    public class DateSerializingTests
+    {
+        public class WhenUsingDateTime
+        {
+            [Fact]
+            public void UtcShouldBeSerializedAsIso()
+            {
+                var utcNow = DateTime.UtcNow;
+                var jsonValue = JsonConvert.SerializeObject(utcNow, CosmosDatabase.CreateJsonSerializerSettings()).Trim('\"');
+                var utcFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF'Z'";
+                var expected = utcNow.ToString(utcFormat);
+                Assert.Equal(expected, jsonValue);
+            }
+
+            [Fact]
+            public void LocalShouldBeSerializedAsIsoWithTimeZone()
+            {
+                var now = DateTime.Now;
+                var jsonValue = JsonConvert.SerializeObject(now, CosmosDatabase.CreateJsonSerializerSettings()).Trim('\"');
+                var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFzzz";
+                var expected = now.ToString(format);
+                Assert.Equal(expected, jsonValue);
+            }
+
+            [Fact]
+            public void UnspecifiedShouldBeSerializedAsIso()
+            {
+                var now = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
+                var jsonValue = JsonConvert.SerializeObject(now, CosmosDatabase.CreateJsonSerializerSettings()).Trim('\"');
+                var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF";
+                var expected = now.ToString(format);
+                Assert.Equal(expected, jsonValue);
+            }
+
+            [Theory]
+            [InlineData("2019-05-08T12:00Z")]
+            [InlineData("2019-05-08T12:00")]
+            public void RoundtripShouldResultInSameValue(string dateTimeString)
+            {
+                var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                var dateTime = DateTime.Parse(dateTimeString);
+                var jsonValue = JsonConvert.SerializeObject(dateTime, serializerSettings);
+                var value = JsonConvert.DeserializeObject<DateTime>(jsonValue, serializerSettings);
+                Assert.Equal(dateTime, value);
+            }
+
+            [Theory]
+            [InlineData("2019-05-08T12:00Z")]
+            [InlineData("2019-05-08T12:00")]
+            public void RoundtripShouldResultInSameKind(string dateTimeString)
+            {
+                var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                var dateTime = DateTime.Parse(dateTimeString);
+                var jsonValue = JsonConvert.SerializeObject(dateTime, serializerSettings);
+                var value = JsonConvert.DeserializeObject<DateTime>(jsonValue, serializerSettings);
+                Assert.Equal(dateTime.Kind, value.Kind);
+            }
+
+            public class WithinObject
+            {
+                [Fact]
+                public void UtcShouldBeSerializedAsIso()
+                {
+                    var utcNow = DateTime.UtcNow;
+                    var entity = new TestEntity
+                    {
+                        DateTime = utcNow
+                    };
+                    var jsonValue = JsonConvert.SerializeObject(entity, CosmosDatabase.CreateJsonSerializerSettings());
+                    var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF'Z'";
+                    var expected = $"{{\"DateTime\":\"{utcNow.ToString(format)}\"}}";
+                    Assert.Equal(expected, jsonValue);
+                }
+
+                [Fact]
+                public void LocalShouldBeSerializedAsIsoWithTimeZone()
+                {
+                    var now = DateTime.Now;
+                    var entity = new TestEntity
+                    {
+                        DateTime = now
+                    };
+                    var jsonValue = JsonConvert.SerializeObject(entity, CosmosDatabase.CreateJsonSerializerSettings());
+                    var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFzzz";
+                    var expected = $"{{\"DateTime\":\"{now.ToString(format)}\"}}";
+                    Assert.Equal(expected, jsonValue);
+                }
+
+                [Fact]
+                public void UnspecifiedShouldBeSerializedAsIso()
+                {
+                    var now = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
+                    var entity = new TestEntity
+                    {
+                        DateTime = now
+                    };
+                    var jsonValue = JsonConvert.SerializeObject(entity, CosmosDatabase.CreateJsonSerializerSettings());
+                    var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF";
+                    var expected = $"{{\"DateTime\":\"{now.ToString(format)}\"}}";
+                    Assert.Equal(expected, jsonValue);
+                }
+
+                [Theory]
+                [InlineData("2019-05-08T12:00Z")]
+                [InlineData("2019-05-08T12:00")]
+                public void ObjectRoundtripShouldResultInSameValue(string dateTimeString)
+                {
+                    var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                    var dateTime = DateTime.Parse(dateTimeString);
+                    var entity = new TestEntity
+                    {
+                        DateTime = dateTime
+                    };
+                    var jsonValue = JsonConvert.SerializeObject(entity, serializerSettings);
+                    var value = JsonConvert.DeserializeObject<TestEntity>(jsonValue, serializerSettings);
+                    Assert.Equal(dateTime, value.DateTime);
+                }
+
+                [Theory]
+                [InlineData("2019-05-08T12:00Z")]
+                [InlineData("2019-05-08T12:00")]
+                public void ObjectRoundtripShouldResultInSameKind(string dateTimeString)
+                {
+                    var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                    var dateTime = DateTime.Parse(dateTimeString);
+                    var entity = new TestEntity
+                    {
+                        DateTime = dateTime
+                    };
+                    var jsonValue = JsonConvert.SerializeObject(entity, serializerSettings);
+                    var value = JsonConvert.DeserializeObject<TestEntity>(jsonValue, serializerSettings);
+                    Assert.Equal(dateTime.Kind, value.DateTime.Kind);
+                }
+
+                public class TestEntity
+                {
+                    public DateTime DateTime { get; set; }
+                }
+            }
+        }
+
+        public class WhenUsingDateTimeOffset
+        {
+            [Fact]
+            public void UtcShouldBeSerializedWithOffset()
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                var jsonValue = JsonConvert.SerializeObject(utcNow, CosmosDatabase.CreateJsonSerializerSettings()).Trim('\"');
+                var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF'+00:00'";
+                var expected = utcNow.ToString(format);
+                Assert.Equal(expected, jsonValue);
+            }
+
+            [Fact]
+            public void LocalShouldBeSerializedWithOffset()
+            {
+                var now = DateTimeOffset.Now;
+                var jsonValue = JsonConvert.SerializeObject(now, CosmosDatabase.CreateJsonSerializerSettings()).Trim('\"');
+                var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF'+0" + now.Offset.Hours + ":00'";
+                var expected = now.ToString(format);
+                Assert.Equal(expected, jsonValue);
+            }
+
+            [Fact]
+            public void PacificShouldBeSerializedWith8HoursOffset()
+            {
+                var offset = TimeSpan.FromHours(8);
+                var dateTimeNow = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
+                var now = new DateTimeOffset(dateTimeNow, offset);
+                var jsonValue = JsonConvert.SerializeObject(now, CosmosDatabase.CreateJsonSerializerSettings()).Trim('\"');
+                var format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFF'+08:00'";
+                var expected = now.ToString(format);
+                Assert.Equal(expected, jsonValue);
+            }
+
+            [Fact]
+            public void PacificShouldBeDeserializedWith8HoursOffset()
+            {
+                var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                var jsonValue = "\"2019-05-08T08:00:00.0000000+08:00\"";
+                var result = JsonConvert.DeserializeObject<DateTimeOffset>(jsonValue, serializerSettings);
+                Assert.Equal(8, result.Offset.Hours);
+            }
+
+            [Theory]
+            [InlineData("2019-05-08T12:00+00:00")]
+            [InlineData("2019-05-08T12:00+02:00")]
+            [InlineData("2019-05-08T12:00+08:00")]
+            [InlineData("2019-05-08T12:00-06:00")]
+            public void RoundtripShouldResultInSameValue(string dateTimeString)
+            {
+                var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                var dateTimeOffset = DateTimeOffset.Parse(dateTimeString);
+                var jsonValue = JsonConvert.SerializeObject(dateTimeOffset, serializerSettings);
+                var value = JsonConvert.DeserializeObject<DateTimeOffset>(jsonValue, serializerSettings);
+                Assert.Equal(dateTimeOffset, value);
+            }
+
+            [Theory]
+            [InlineData("2019-05-08T12:00+00:00")]
+            [InlineData("2019-05-08T12:00+02:00")]
+            [InlineData("2019-05-08T12:00+08:00")]
+            [InlineData("2019-05-08T12:00-06:00")]
+            public void RoundtripShouldResultInSameOffset(string dateTimeString)
+            {
+                var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                var dateTimeOffset = DateTimeOffset.Parse(dateTimeString);
+                var jsonValue = JsonConvert.SerializeObject(dateTimeOffset, serializerSettings);
+                var value = JsonConvert.DeserializeObject<DateTimeOffset>(jsonValue, serializerSettings);
+                Assert.Equal(dateTimeOffset.Offset, value.Offset);
+            }
+
+            public class WithinObject
+            {
+                [Theory]
+                [InlineData("2019-05-08T12:00+00:00")]
+                [InlineData("2019-05-08T12:00+02:00")]
+                [InlineData("2019-05-08T12:00+08:00")]
+                [InlineData("2019-05-08T12:00-06:00")]
+                public void ObjectRoundtripShouldResultInSameValue(string dateTimeString)
+                {
+                    var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                    var dateTimeOffset = DateTimeOffset.Parse(dateTimeString);
+                    var entity = new TestEntity
+                    {
+                        DateTimeOffset = dateTimeOffset
+                    };
+                    var jsonValue = JsonConvert.SerializeObject(entity, serializerSettings);
+                    var value = JsonConvert.DeserializeObject<TestEntity>(jsonValue, serializerSettings);
+                    Assert.Equal(dateTimeOffset, value.DateTimeOffset);
+                }
+
+                [Theory]
+                [InlineData("2019-05-08T12:00+00:00")]
+                [InlineData("2019-05-08T12:00+02:00")]
+                [InlineData("2019-05-08T12:00+08:00")]
+                [InlineData("2019-05-08T12:00-06:00")]
+                public void ObjectRoundtripShouldResultInSameOffset(string dateTimeString)
+                {
+                    var serializerSettings = CosmosDatabase.CreateJsonSerializerSettings();
+                    var dateTimeOffset = DateTimeOffset.Parse(dateTimeString);
+                    var entity = new TestEntity
+                    {
+                        DateTimeOffset = dateTimeOffset
+                    };
+                    var jsonValue = JsonConvert.SerializeObject(entity, serializerSettings);
+                    var value = JsonConvert.DeserializeObject<TestEntity>(jsonValue, serializerSettings);
+                    Assert.Equal(dateTimeOffset.Offset, value.DateTimeOffset.Offset);
+                }
+
+                public class TestEntity
+                {
+                    public DateTimeOffset DateTimeOffset { get; set; }
+                }
+            }
+        }
+    }
+}

--- a/Spinit.CosmosDb.sln
+++ b/Spinit.CosmosDb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.136
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spinit.CosmosDb", "Spinit.CosmosDb\Spinit.CosmosDb.csproj", "{40EC2E59-8CA4-4E33-B884-1DF26E42B378}"
 EndProject
@@ -15,7 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TodoApi", "TodoApi", "{9269
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoApi", "Examples\TodoApi\TodoApi.csproj", "{8E61C596-01C7-4698-B326-485B1C9E7020}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spinit.CosmosDb.FunctionalTests", "Spinit.CosmosDb.FunctionalTests\Spinit.CosmosDb.FunctionalTests.csproj", "{0D78AA6C-0471-430B-8985-B3875C0D8B04}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spinit.CosmosDb.FunctionalTests", "Spinit.CosmosDb.FunctionalTests\Spinit.CosmosDb.FunctionalTests.csproj", "{0D78AA6C-0471-430B-8985-B3875C0D8B04}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Spinit.CosmosDb/CosmosDatabase.cs
+++ b/Spinit.CosmosDb/CosmosDatabase.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
+using Newtonsoft.Json;
 
 namespace Spinit.CosmosDb
 {
@@ -47,7 +48,14 @@ namespace Spinit.CosmosDb
         private readonly IDatabaseOptions _options;
 
         protected CosmosDatabase(IDatabaseOptions options)
-            : this(new DocumentClient(new Uri(options.Endpoint), options.Key, connectionPolicy: CreateConnectionPolicy(options)), options)
+            : this(new DocumentClient(
+                new Uri(options.Endpoint), 
+                options.Key, 
+                connectionPolicy: CreateConnectionPolicy(options), 
+                serializerSettings: new JsonSerializerSettings
+                {
+                    DateParseHandling = DateParseHandling.DateTimeOffset,
+                }), options)
         { }
 
         internal static ConnectionPolicy CreateConnectionPolicy(IDatabaseOptions options)

--- a/Spinit.CosmosDb/CosmosDatabase.cs
+++ b/Spinit.CosmosDb/CosmosDatabase.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Spinit.CosmosDb
 {
@@ -48,14 +49,13 @@ namespace Spinit.CosmosDb
         private readonly IDatabaseOptions _options;
 
         protected CosmosDatabase(IDatabaseOptions options)
-            : this(new DocumentClient(
-                new Uri(options.Endpoint), 
-                options.Key, 
-                connectionPolicy: CreateConnectionPolicy(options), 
-                serializerSettings: new JsonSerializerSettings
-                {
-                    DateParseHandling = DateParseHandling.DateTimeOffset,
-                }), options)
+            : this(
+                new DocumentClient(
+                    new Uri(options.Endpoint),
+                    options.Key,
+                    connectionPolicy: CreateConnectionPolicy(options),
+                    serializerSettings: CreateJsonSerializerSettings()
+                ), options)
         { }
 
         internal static ConnectionPolicy CreateConnectionPolicy(IDatabaseOptions options)
@@ -68,6 +68,18 @@ namespace Spinit.CosmosDb
             if (!string.IsNullOrEmpty(options.PreferredLocation))
                 connectionPolicy.PreferredLocations.Add(options.PreferredLocation);
             return connectionPolicy;
+        }
+
+        internal static JsonSerializerSettings CreateJsonSerializerSettings()
+        {
+            return new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.None,
+                Converters = new[]
+                {
+                    new IsoDateTimeConverter()
+                }
+            };
         }
 
         internal CosmosDatabase(IDocumentClient documentClient, IDatabaseOptions options)


### PR DESCRIPTION
Fixes: #18

This defaults to `DateParseHandling.DateTimeOffset`. But this is something that you might want configurable. Might be nice to have access to `JsonSerializerSettings` somehow, but I leave that up to @martin-oom 😄.