### PR TITLE
Removed default TTL.

### DIFF
--- a/Spinit.CosmosDb/Internals/DatabaseOperations.cs
+++ b/Spinit.CosmosDb/Internals/DatabaseOperations.cs
@@ -34,7 +34,6 @@ namespace Spinit.CosmosDb
                                 .Attach()
                         .WithIndexingMode(IndexingMode.Consistent)
                             .Attach()
-                    .WithDefaultTimeToLive(30)
                     .CreateIfNotExistsAsync()
                     .ConfigureAwait(false);
             }


### PR DESCRIPTION
A default time to live was set to 30 seconds on newly created containers. The option should not be set.