### PR TITLE
Set container throughput

### DIFF
--- a/Spinit.CosmosDb.FunctionalTests/CreateDatabaseTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/CreateDatabaseTests.cs
@@ -25,7 +25,7 @@ namespace Spinit.CosmosDb.FunctionalTests
             var database = new DummyDatabase();
             
             await database.Operations.CreateIfNotExistsAsync();
-            var throughput = await database.Dummies.ReadThroughputAsync();
+            var throughput = await database.Dummies.GetThroughputAsync();
             await database.Operations.DeleteAsync();
 
             Assert.Equal(400, throughput);
@@ -40,7 +40,7 @@ namespace Spinit.CosmosDb.FunctionalTests
             var database = new DummyDatabase();
 
             await database.Operations.CreateIfNotExistsAsync(defaultThroughput);
-            var throughput = await database.Dummies.ReadThroughputAsync();
+            var throughput = await database.Dummies.GetThroughputAsync();
             await database.Operations.DeleteAsync();
 
             Assert.Equal(expected, throughput);

--- a/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
@@ -180,14 +180,14 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         public async Task TestReadCollectionThroughput()
         {
-            await _database.Todos.ReadThroughputAsync();
+            await _database.Todos.GetThroughputAsync();
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
         public async Task TestReplaceCollectionThroughput()
         {
-            await _database.Todos.ReplaceThroughputAsync(1000);
+            await _database.Todos.SetThroughputAsync(1000);
         }
 
 
@@ -195,7 +195,7 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         public async Task TestReadNewlyReplacedThrouhgput()
         {
-            var throughput = await _database.Todos.ReadThroughputAsync();
+            var throughput = await _database.Todos.GetThroughputAsync();
             Assert.Equal(1000, throughput);
         }
 
@@ -203,7 +203,7 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         public async Task TestReplaceThroughputWithInvalidThroughput()
         {
-            await Assert.ThrowsAsync<ArgumentException>(async () => await _database.Todos.ReplaceThroughputAsync(399));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await _database.Todos.SetThroughputAsync(399));
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]

--- a/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
@@ -178,6 +178,36 @@ namespace Spinit.CosmosDb.FunctionalTests
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
+        public async Task TestReadCollectionThroughput()
+        {
+            await _database.Todos.ReadThroughputAsync();
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestReplaceCollectionThroughput()
+        {
+            await _database.Todos.ReplaceThroughputAsync(1000);
+        }
+
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestReadNewlyReplacedThrouhgput()
+        {
+            var throughput = await _database.Todos.ReadThroughputAsync();
+            Assert.Equal(1000, throughput);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestReplaceThroughputWithInvalidThroughput()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(async () => await _database.Todos.ReplaceThroughputAsync(399));
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
         public async Task DeleteDatabase()
         {
             await _database.Operations.DeleteAsync();

--- a/Spinit.CosmosDb.UnitTests/Internals/ExpressionExtensionsTests.cs
+++ b/Spinit.CosmosDb.UnitTests/Internals/ExpressionExtensionsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Spinit.CosmosDb.Validation;
 using Spinit.Expressions;
 using Xunit;
 

--- a/Spinit.CosmosDb.UnitTests/Validation/ThroughputValidationTests.cs
+++ b/Spinit.CosmosDb.UnitTests/Validation/ThroughputValidationTests.cs
@@ -1,0 +1,23 @@
+﻿using Spinit.CosmosDb.Validation;
+using Xunit;
+
+namespace Spinit.CosmosDb.UnitTests.Validation
+{
+    public class ThroughputValidationTests
+    {
+        [Theory]
+        [InlineData(100, false)]
+        [InlineData(300, false)]
+        [InlineData(399, false)]
+        [InlineData(400, true)]
+        [InlineData(550, false)]
+        [InlineData(10000, true)]
+        [InlineData(1000000, true)]
+        [InlineData(1000001, false)]
+        public void TestIsValidThoughput(int throughput, bool expected)
+        {
+            var isValid = ThroughputValidator.IsValidThroughput(throughput);
+            Assert.Equal(expected, isValid);
+        }
+    }
+}

--- a/Spinit.CosmosDb/ICosmosDbCollection.cs
+++ b/Spinit.CosmosDb/ICosmosDbCollection.cs
@@ -54,5 +54,18 @@ namespace Spinit.CosmosDb
         /// <param name="ids"></param>
         /// <returns></returns>
         Task DeleteAsync(IEnumerable<string> ids);
+
+        /// <summary>
+        /// Reads the throughput (RU:s) set for the collection.
+        /// </summary>
+        /// <returns>The collection's throughput</returns>
+        Task<int?> ReadThroughputAsync();
+
+        /// <summary>
+        /// Replaces the throughput (RU:s) for the collection.
+        /// </summary>
+        /// <param name="throughput">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
+        /// <returns></returns>
+        Task ReplaceThroughputAsync(int throughput);
     }
 }

--- a/Spinit.CosmosDb/ICosmosDbCollection.cs
+++ b/Spinit.CosmosDb/ICosmosDbCollection.cs
@@ -56,13 +56,13 @@ namespace Spinit.CosmosDb
         Task DeleteAsync(IEnumerable<string> ids);
 
         /// <summary>
-        /// Gets the throughput (RU:s) set for the collection.
+        /// Gets the throughput (RU/s) set for the collection.
         /// </summary>
         /// <returns>The collection's throughput</returns>
         Task<int?> GetThroughputAsync();
 
         /// <summary>
-        /// Sets the throughput (RU:s) for the collection.
+        /// Sets the throughput (RU/s) for the collection.
         /// </summary>
         /// <param name="throughput">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
         /// <returns></returns>

--- a/Spinit.CosmosDb/ICosmosDbCollection.cs
+++ b/Spinit.CosmosDb/ICosmosDbCollection.cs
@@ -56,16 +56,16 @@ namespace Spinit.CosmosDb
         Task DeleteAsync(IEnumerable<string> ids);
 
         /// <summary>
-        /// Reads the throughput (RU:s) set for the collection.
+        /// Gets the throughput (RU:s) set for the collection.
         /// </summary>
         /// <returns>The collection's throughput</returns>
-        Task<int?> ReadThroughputAsync();
+        Task<int?> GetThroughputAsync();
 
         /// <summary>
-        /// Replaces the throughput (RU:s) for the collection.
+        /// Sets the throughput (RU:s) for the collection.
         /// </summary>
         /// <param name="throughput">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
         /// <returns></returns>
-        Task ReplaceThroughputAsync(int throughput);
+        Task SetThroughputAsync(int throughput);
     }
 }

--- a/Spinit.CosmosDb/IDatabaseOperations.cs
+++ b/Spinit.CosmosDb/IDatabaseOperations.cs
@@ -8,8 +8,9 @@ namespace Spinit.CosmosDb
         /// <summary>
         /// Creates the Cosmos database and defined collections if not exists.
         /// </summary>
+        /// <param name="containerThroughput">Optional parameter to specify the throughput (RU:s) the containers should be created with. Defaults to 400.</param>
         /// <returns></returns>
-        Task CreateIfNotExistsAsync();
+        Task CreateIfNotExistsAsync(int containerThroughput = 400);
 
         /// <summary>
         /// Deletes the Cosmos database.

--- a/Spinit.CosmosDb/IDatabaseOperations.cs
+++ b/Spinit.CosmosDb/IDatabaseOperations.cs
@@ -8,7 +8,7 @@ namespace Spinit.CosmosDb
         /// <summary>
         /// Creates the Cosmos database and defined collections if not exists.
         /// </summary>
-        /// <param name="containerThroughput">Optional parameter to specify the throughput (RU:s) the containers should be created with. Defaults to 400.</param>
+        /// <param name="containerThroughput">Optional parameter to specify the throughput (RU/s) the containers should be created with. Defaults to 400.</param>
         /// <returns></returns>
         Task CreateIfNotExistsAsync(int containerThroughput = 400);
 

--- a/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
+++ b/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
@@ -133,9 +133,9 @@ namespace Spinit.CosmosDb
             } while (bulkDeleteResponse.NumberOfDocumentsDeleted < entries.Count && bulkDeleteResponse.NumberOfDocumentsDeleted > 0);
         }
 
-        public async Task<int?> GetThroughputAsync()
+        public Task<int?> GetThroughputAsync()
         {
-            return await _container.ReadThroughputAsync().ConfigureAwait(false);
+            return _container.ReadThroughputAsync();
         }
 
         public Task SetThroughputAsync(int throughput)
@@ -145,12 +145,7 @@ namespace Spinit.CosmosDb
                 throw new ArgumentException("The provided throughput is not valid. Must be between 400 and 1000000 and in increments of 100.", nameof(throughput));
             }
 
-            return SetThroughputInternalAsync(throughput);
-        }
-
-        private async Task SetThroughputInternalAsync(int throughput)
-        {
-            await _container.ReplaceThroughputAsync(throughput).ConfigureAwait(false);
+            return _container.ReplaceThroughputAsync(throughput);
         }
 
         internal protected virtual async Task<SearchResponse<TProjection>> ExecuteSearchAsync<TProjection>(ISearchRequest<TEntity> request)

--- a/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
+++ b/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
@@ -138,13 +138,18 @@ namespace Spinit.CosmosDb
             return await _container.ReadThroughputAsync().ConfigureAwait(false);
         }
 
-        public async Task ReplaceThroughputAsync(int throughput)
+        public Task ReplaceThroughputAsync(int throughput)
         {
             if (!ThroughputValidator.IsValidThroughput(throughput))
             {
                 throw new ArgumentException("The provided throughput is not valid. Must be between 400 and 1000000 and in increments of 100.", nameof(throughput));
             }
 
+            return ReplaceThroughputInternalAsync(throughput);
+        }
+
+        private async Task ReplaceThroughputInternalAsync(int throughput)
+        {
             await _container.ReplaceThroughputAsync(throughput).ConfigureAwait(false);
         }
 

--- a/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
+++ b/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
@@ -12,6 +12,7 @@ using Documents = Microsoft.Azure.Documents;
 using Spinit.Expressions;
 using System.IO;
 using Newtonsoft.Json;
+using Spinit.CosmosDb.Validation;
 
 namespace Spinit.CosmosDb
 {
@@ -130,6 +131,21 @@ namespace Spinit.CosmosDb
                     .BulkDeleteAsync(entries)
                     .ConfigureAwait(false);
             } while (bulkDeleteResponse.NumberOfDocumentsDeleted < entries.Count && bulkDeleteResponse.NumberOfDocumentsDeleted > 0);
+        }
+
+        public async Task<int?> ReadThroughputAsync()
+        {
+            return await _container.ReadThroughputAsync().ConfigureAwait(false);
+        }
+
+        public async Task ReplaceThroughputAsync(int throughput)
+        {
+            if (!ThroughputValidator.IsValidThroughput(throughput))
+            {
+                throw new ArgumentException("The provided throughput is not valid. Must be between 400 and 1000000 and in increments of 100.", nameof(throughput));
+            }
+
+            await _container.ReplaceThroughputAsync(throughput).ConfigureAwait(false);
         }
 
         internal protected virtual async Task<SearchResponse<TProjection>> ExecuteSearchAsync<TProjection>(ISearchRequest<TEntity> request)

--- a/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
+++ b/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
@@ -133,22 +133,22 @@ namespace Spinit.CosmosDb
             } while (bulkDeleteResponse.NumberOfDocumentsDeleted < entries.Count && bulkDeleteResponse.NumberOfDocumentsDeleted > 0);
         }
 
-        public async Task<int?> ReadThroughputAsync()
+        public async Task<int?> GetThroughputAsync()
         {
             return await _container.ReadThroughputAsync().ConfigureAwait(false);
         }
 
-        public Task ReplaceThroughputAsync(int throughput)
+        public Task SetThroughputAsync(int throughput)
         {
             if (!ThroughputValidator.IsValidThroughput(throughput))
             {
                 throw new ArgumentException("The provided throughput is not valid. Must be between 400 and 1000000 and in increments of 100.", nameof(throughput));
             }
 
-            return ReplaceThroughputInternalAsync(throughput);
+            return SetThroughputInternalAsync(throughput);
         }
 
-        private async Task ReplaceThroughputInternalAsync(int throughput)
+        private async Task SetThroughputInternalAsync(int throughput)
         {
             await _container.ReplaceThroughputAsync(throughput).ConfigureAwait(false);
         }

--- a/Spinit.CosmosDb/Internals/DatabaseOperations.cs
+++ b/Spinit.CosmosDb/Internals/DatabaseOperations.cs
@@ -20,13 +20,18 @@ namespace Spinit.CosmosDb
         /// Creates the Cosmos database and defined collections if not exists.
         /// </summary>
         /// <returns></returns>
-        public async Task CreateIfNotExistsAsync(int containerThroughput = 400)
+        public Task CreateIfNotExistsAsync(int containerThroughput = 400)
         {
             if (!ThroughputValidator.IsValidThroughput(containerThroughput))
             {
                 throw new ArgumentException("The provided throughput is not valid. Must be between 400 and 1000000 and in increments of 100.", nameof(containerThroughput));
             }
 
+            return CreateIfNotExistsInternalAsync(containerThroughput);
+        }
+
+        private async Task CreateIfNotExistsInternalAsync(int containerThroughput = 400)
+        {
             var databaseId = _database.Model.DatabaseId;
 
             await _cosmosClient.CreateDatabaseIfNotExistsAsync(databaseId).ConfigureAwait(false);

--- a/Spinit.CosmosDb/Internals/DatabaseOperations.cs
+++ b/Spinit.CosmosDb/Internals/DatabaseOperations.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Azure.Cosmos;
+using Spinit.CosmosDb.Validation;
+using System;
 using System.Threading.Tasks;
 
 namespace Spinit.CosmosDb
@@ -18,8 +20,13 @@ namespace Spinit.CosmosDb
         /// Creates the Cosmos database and defined collections if not exists.
         /// </summary>
         /// <returns></returns>
-        public async Task CreateIfNotExistsAsync()
+        public async Task CreateIfNotExistsAsync(int containerThroughput = 400)
         {
+            if (!ThroughputValidator.IsValidThroughput(containerThroughput))
+            {
+                throw new ArgumentException("The provided throughput is not valid. Must be between 400 and 1000000 and in increments of 100.", nameof(containerThroughput));
+            }
+
             var databaseId = _database.Model.DatabaseId;
 
             await _cosmosClient.CreateDatabaseIfNotExistsAsync(databaseId).ConfigureAwait(false);
@@ -34,7 +41,7 @@ namespace Spinit.CosmosDb
                                 .Attach()
                         .WithIndexingMode(IndexingMode.Consistent)
                             .Attach()
-                    .CreateIfNotExistsAsync()
+                    .CreateIfNotExistsAsync(containerThroughput)
                     .ConfigureAwait(false);
             }
         }

--- a/Spinit.CosmosDb/Validation/ThroughputValidator.cs
+++ b/Spinit.CosmosDb/Validation/ThroughputValidator.cs
@@ -1,0 +1,7 @@
+﻿namespace Spinit.CosmosDb.Validation
+{
+    internal static class ThroughputValidator
+    {
+        internal static bool IsValidThroughput(int throughput) => throughput % 100 == 0 && throughput >= 400 && throughput <= 1000000;
+    }
+}


### PR DESCRIPTION
Adds support for setting container throughput.

- Can now specifiy throughput for containers when using `CreateIfNotExistsAsync()`. Defaults to 400.
- Can now read a collections throughput with `ReadThroughputAsync()`.
- Can now update a collections throughput with `ReplaceThroughputAsync(int)`