### PR TITLE
Allow setting database or container throughput on db creation.

### DIFF
--- a/Spinit.CosmosDb.FunctionalTests/CreateDatabaseTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/CreateDatabaseTests.cs
@@ -35,11 +35,11 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         [InlineData(500, 500)]
         [InlineData(1000, 1000)]
-        public async Task TestCreateDatabaseWithtDefaultThroughputSet(int defaultThroughput, int expected)
+        public async Task TestCreateDatabaseWithtDefaultContainerThroughputSet(int defaultThroughput, int expected)
         {
             var database = new DummyDatabase();
 
-            await database.Operations.CreateIfNotExistsAsync(defaultThroughput);
+            await database.Operations.CreateIfNotExistsAsync(new CreateDbOptions(defaultThroughput, ThroughputType.Container));
             var throughput = await database.Dummies.GetThroughputAsync();
             await database.Operations.DeleteAsync();
 
@@ -56,7 +56,22 @@ namespace Spinit.CosmosDb.FunctionalTests
         {
             var database = new DummyDatabase();
 
-            await Assert.ThrowsAsync<ArgumentException>(async () => await database.Operations.CreateIfNotExistsAsync(defaultThroughput));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await database.Operations.CreateIfNotExistsAsync(new CreateDbOptions(defaultThroughput, ThroughputType.Container)));
+        }
+
+        [Theory(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        [InlineData(500, 500)]
+        [InlineData(1000, 1000)]
+        public async Task TestCreateDatabaseWithDefaultDatabaseThroughputSet(int defaultThroughput, int expected)
+        {
+            var database = new DummyDatabase();
+
+            await database.Operations.CreateIfNotExistsAsync(new CreateDbOptions(defaultThroughput, ThroughputType.Database));
+            var throughput = await database.Operations.GetThroughputAsync();
+            await database.Operations.DeleteAsync();
+
+            Assert.Equal(expected, throughput);
         }
 
         public class DummyDatabase : CosmosDatabase

--- a/Spinit.CosmosDb.FunctionalTests/FunctionalCollectionThroughputTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalCollectionThroughputTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading.Tasks;
+using Spinit.CosmosDb.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Spinit.CosmosDb.FunctionalTests
+{
+    [TestCaseOrderer("Spinit.CosmosDb.FunctionalTests.Infrastructure.TestCaseByAttributeOrderer", "Spinit.CosmosDb.FunctionalTests")]
+    public class FunctionalCollectionThroughputTests : IClassFixture<FunctionalCollectionThroughputTests.TestDatabase>
+    {
+        private readonly TestDatabase _database;
+
+        public FunctionalCollectionThroughputTests(TestDatabase database)
+        {
+            _database = database;
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task CreateDatabaseWithContainerThroughput()
+        {
+            await _database.Operations.CreateIfNotExistsAsync(new CreateDbOptions(1000, ThroughputType.Container));
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestReadCollectionThroughput()
+        {
+            var throughput = await _database.Todos.GetThroughputAsync();
+            Assert.Equal(1000, throughput);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestSetDatabaseThroughput()
+        {
+            await _database.Todos.SetThroughputAsync(400);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestGetDatabaseThroughputAfterSet()
+        {
+            var throughput = await _database.Todos.GetThroughputAsync();
+            Assert.Equal(400, throughput);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestDeleteDatabase()
+        {
+            await _database.Operations.DeleteAsync();
+        }
+
+        public class TestDatabase : CosmosDatabase
+        {
+            public TestDatabase()
+                : base(new DatabaseOptionsBuilder<TestDatabase>().UseConnectionString(GenerateConnectionString()).Options)
+            { }
+
+            private static string GenerateConnectionString()
+            {
+                var databaseId = $"db-{Guid.NewGuid().ToString("N")}";
+                return $"{FunctionTestsConfiguration.CosmosDbConnectionString};DatabaseId={databaseId}";
+            }
+
+            public ICosmosDbCollection<TodoItem> Todos { get; set; }
+        }
+
+        public class TodoItem : ICosmosEntity
+        {
+            public string Id { get; set; }
+        }
+    }
+}

--- a/Spinit.CosmosDb.FunctionalTests/FunctionalDatabaseThroughputTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalDatabaseThroughputTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+using Spinit.CosmosDb.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Spinit.CosmosDb.FunctionalTests
+{
+    [TestCaseOrderer("Spinit.CosmosDb.FunctionalTests.Infrastructure.TestCaseByAttributeOrderer", "Spinit.CosmosDb.FunctionalTests")]
+    public class FunctionalDatabaseThroughputTests : IClassFixture<FunctionalDatabaseThroughputTests.TestDatabase>
+    {
+        private readonly TestDatabase _database;
+
+        public FunctionalDatabaseThroughputTests(TestDatabase database)
+        {
+            _database = database;
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task CreateDatabaseWithDatabaseThroughput()
+        {
+            await _database.Operations.CreateIfNotExistsAsync(new CreateDbOptions(1000, ThroughputType.Database));
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestReadDatabaseThroughput()
+        {
+            var throughput = await _database.Operations.GetThroughputAsync();
+            Assert.Equal(1000, throughput);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestSetDatabaseThroughput()
+        {
+            await _database.Operations.SetThroughputAsync(400);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestGetDatabaseThroughputAfterSet()
+        {
+            var throughput = await _database.Operations.GetThroughputAsync();
+            Assert.Equal(400, throughput);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestDeleteDatabase()
+        {
+            await _database.Operations.DeleteAsync();
+        }
+
+        public class TestDatabase : CosmosDatabase
+        {
+            public TestDatabase()
+                : base(new DatabaseOptionsBuilder<TestDatabase>().UseConnectionString(GenerateConnectionString()).Options)
+            { }
+
+            private static string GenerateConnectionString()
+            {
+                var databaseId = $"db-{Guid.NewGuid().ToString("N")}";
+                return $"{FunctionTestsConfiguration.CosmosDbConnectionString};DatabaseId={databaseId}";
+            }
+
+        }
+    }
+}

--- a/Spinit.CosmosDb/IDatabaseOperations.cs
+++ b/Spinit.CosmosDb/IDatabaseOperations.cs
@@ -8,9 +8,9 @@ namespace Spinit.CosmosDb
         /// <summary>
         /// Creates the Cosmos database and defined collections if not exists.
         /// </summary>
-        /// <param name="createOptions">Optional parameter to specify the throughput (RU/s) the database or container should be created with.</param>
+        /// <param name="options">Optional parameter to specify the throughput (RU/s) the database or container should be created with.</param>
         /// <returns></returns>
-        public Task CreateIfNotExistsAsync(CreateDbOptions createOptions = null);
+        public Task CreateIfNotExistsAsync(CreateDbOptions options = null);
 
         /// <summary>
         /// Deletes the Cosmos database.

--- a/Spinit.CosmosDb/IDatabaseOperations.cs
+++ b/Spinit.CosmosDb/IDatabaseOperations.cs
@@ -8,14 +8,27 @@ namespace Spinit.CosmosDb
         /// <summary>
         /// Creates the Cosmos database and defined collections if not exists.
         /// </summary>
-        /// <param name="containerThroughput">Optional parameter to specify the throughput (RU/s) the containers should be created with. Defaults to 400.</param>
+        /// <param name="createOptions">Optional parameter to specify the throughput (RU/s) the database or container should be created with.</param>
         /// <returns></returns>
-        Task CreateIfNotExistsAsync(int containerThroughput = 400);
+        public Task CreateIfNotExistsAsync(CreateDbOptions createOptions = null);
 
         /// <summary>
         /// Deletes the Cosmos database.
         /// </summary>
         /// <returns></returns>
         Task DeleteAsync();
+
+        /// <summary>
+        /// Gets the throughput (RU/s) set for the collection.
+        /// </summary>
+        /// <returns></returns>
+        Task<int?> GetThroughputAsync();
+
+        /// <summary>
+        /// Sets the throughput (RU/s) for the database.
+        /// </summary>
+        /// <param name="throughput">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
+        /// <returns></returns>
+        Task SetThroughputAsync(int throughput);
     }
 }

--- a/Spinit.CosmosDb/Internals/CreateDbOptions.cs
+++ b/Spinit.CosmosDb/Internals/CreateDbOptions.cs
@@ -2,6 +2,11 @@
 {
     public class CreateDbOptions
     {
+        /// <summary>
+        /// Options for when creating a new database.
+        /// </summary>
+        /// <param name="throughput">The throughput to set. Must be between 400 and 1000000 and in increments of 100.</param>
+        /// <param name="throughputType">Where to set the default throughput. Sets the throughput for all containers if Container is selected.</param>
         public CreateDbOptions(int throughput, ThroughputType throughputType)
         {
             Throughput = throughput;

--- a/Spinit.CosmosDb/Internals/CreateDbOptions.cs
+++ b/Spinit.CosmosDb/Internals/CreateDbOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Spinit.CosmosDb
+{
+    public class CreateDbOptions
+    {
+        public CreateDbOptions(int throughput, ThroughputType throughputType)
+        {
+            Throughput = throughput;
+            ThroughputType = throughputType;
+        }
+
+        public int Throughput { get; }
+        public ThroughputType ThroughputType { get; }
+    }
+}

--- a/Spinit.CosmosDb/Internals/ThroughputType.cs
+++ b/Spinit.CosmosDb/Internals/ThroughputType.cs
@@ -1,0 +1,8 @@
+﻿namespace Spinit.CosmosDb
+{
+    public enum ThroughputType
+    {
+        Database,
+        Container
+    }
+}


### PR DESCRIPTION
Added functionality to set and get the throughput on an entire database or on a container.