### PR TITLE
More serialization configuration

### DIFF
--- a/Spinit.CosmosDb.UnitTests/Internals/JsonSerializingTests.cs
+++ b/Spinit.CosmosDb.UnitTests/Internals/JsonSerializingTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -57,6 +58,7 @@ namespace Spinit.CosmosDb.UnitTests.Internals
             public string DatabaseId { get; set; }
             public string PreferredLocation { get; set; }
             public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
+            public Action<CosmosClientOptions> ConfigureCosmosClientOptions { get; set; }
         }
 
         public class VersionJsonConverter : JsonConverter

--- a/Spinit.CosmosDb/CosmosDatabase.cs
+++ b/Spinit.CosmosDb/CosmosDatabase.cs
@@ -60,7 +60,7 @@ namespace Spinit.CosmosDb
                 new CosmosClient(
                     new Uri(options.Endpoint).AbsoluteUri,
                     options.Key,
-                    new CosmosClientOptions()
+                    CreateCosmosClientOptions(options)
                 ), options, initialize)
         { }
 
@@ -76,6 +76,13 @@ namespace Spinit.CosmosDb
                 connectionPolicy.PreferredLocations.Add(options.PreferredLocation);
 
             return connectionPolicy;
+        }
+
+        internal static CosmosClientOptions CreateCosmosClientOptions(IDatabaseOptions options = null)
+        {
+            var clientOptions = new CosmosClientOptions();
+            options?.ConfigureCosmosClientOptions?.Invoke(clientOptions);
+            return clientOptions;
         }
 
         internal static JsonSerializerSettings CreateJsonSerializerSettings(IDatabaseOptions options = null)

--- a/Spinit.CosmosDb/DatabaseOptions.cs
+++ b/Spinit.CosmosDb/DatabaseOptions.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
 using System;
 
 namespace Spinit.CosmosDb
@@ -20,9 +21,10 @@ namespace Spinit.CosmosDb
         /// </summary>
         public string PreferredLocation { get; set; }
 
-        /// <summary>
-        /// Optional Json serialization settings configuration
-        /// </summary>
+        /// <inheritdoc/>
         public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
+
+        /// <inheritdoc/>
+        public Action<CosmosClientOptions> ConfigureCosmosClientOptions { get; set; }
     }
 }

--- a/Spinit.CosmosDb/IDatabaseOptions.cs
+++ b/Spinit.CosmosDb/IDatabaseOptions.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
 using System;
 
 namespace Spinit.CosmosDb
@@ -19,6 +20,14 @@ namespace Spinit.CosmosDb
         /// </summary>
         string PreferredLocation { get; set; }
 
+        /// <summary>
+        /// Configure document client json serializer settings
+        /// </summary>
         Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
+
+        /// <summary>
+        /// Configure CosmosClient options
+        /// </summary>
+        Action<CosmosClientOptions> ConfigureCosmosClientOptions { get; set; }
     }
 }


### PR DESCRIPTION
Enables configuration of `CosmosClient` in order to fully configure serialization (until #40 is solved).
This PR enables a user to configure the same serialization for both DocumentClient and CosmosClient which is a bit cumbersome, but at least possible. Example:
```csharp
public static DatabaseOptions<MyDatbase> BuildDatabaseOptions(string connectionString)
{
    var builder = new DatabaseOptionsBuilder<MyDatbase>().UseConnectionString(connectionString);
    builder.Options.DatabaseId = "MyDb";
    builder.Options.ConfigureJsonSerializerSettings = settings =>
    {
        settings.Converters.Add(new CosmosDbJsonSerialization.CustomJsonConverter());
        builder.Options.ConfigureCosmosClientOptions = options =>
        {
            options.Serializer = new CosmosDbJsonSerialization.CosmosJsonNetSerializer(settings);
        };
    };

    return builder.Options;
}
```
An example of a `CosmosJsonNetSerializer` can be found here: https://gist.github.com/richstokoe/c82fc831c6b4020926f5b5f772f7cd70