### PR TITLE
Serialization, take three. Third time's a charm?

### DIFF
--- a/Spinit.CosmosDb/CosmosDatabase.cs
+++ b/Spinit.CosmosDb/CosmosDatabase.cs
@@ -53,6 +53,7 @@ namespace Spinit.CosmosDb
     {
         private readonly Documents.IDocumentClient _documentClient;
         private readonly IDatabaseOptions _options;
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
 
         protected CosmosDatabase(IDatabaseOptions options, bool initialize = true)
             : this(
@@ -62,7 +63,8 @@ namespace Spinit.CosmosDb
                     options.Key,
                     CreateCosmosClientOptions(options)
                 ), options, initialize)
-        { }
+        {
+        }
 
         internal static Documents.Client.ConnectionPolicy CreateConnectionPolicy(IDatabaseOptions options)
         {
@@ -105,8 +107,9 @@ namespace Spinit.CosmosDb
         {
             _documentClient = documentClient;
             CosmosClient = cosmosClient;
+            _jsonSerializerSettings = CreateJsonSerializerSettings(options);
             _options = options;
-
+            
             if (initialize)
             {
                 Initialize();
@@ -174,7 +177,7 @@ namespace Spinit.CosmosDb
             if (string.IsNullOrEmpty(collectionModel.CollectionId))
                 collectionModel.CollectionId = collectionProperty.GetCollectionId();
 
-            var collection = new CosmosDbCollection<TEntity>(CosmosClient.GetContainer(collectionModel.DatabaseId, collectionModel.CollectionId), _documentClient, collectionModel);
+            var collection = new CosmosDbCollection<TEntity>(CosmosClient.GetContainer(collectionModel.DatabaseId, collectionModel.CollectionId), _documentClient, collectionModel, _jsonSerializerSettings);
             collectionProperty.SetValue(this, collection);
         }
 

--- a/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
+++ b/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
@@ -31,12 +31,14 @@ namespace Spinit.CosmosDb
         private readonly Container _container;
         private readonly Documents.IDocumentClient _documentClient;
         private readonly CollectionModel _model;
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
 
-        public CosmosDbCollection(Container container, Documents.IDocumentClient documentClient, CollectionModel model)
+        public CosmosDbCollection(Container container, Documents.IDocumentClient documentClient, CollectionModel model, JsonSerializerSettings settings = null)
         {
             _container = container;
             _documentClient = documentClient;
             _model = model;
+            _jsonSerializerSettings = settings ?? new JsonSerializerSettings();
         }
 
         public Task<SearchResponse<TEntity>> SearchAsync(ISearchRequest<TEntity> request) => SearchAsync<TEntity>(request);
@@ -188,8 +190,7 @@ namespace Spinit.CosmosDb
             }
             using var streamReader = new StreamReader(streamResponse.Content);
             using var jsonTextReader = new JsonTextReader(streamReader);
-
-            var response = JsonConvert.DeserializeObject<CosmosStreamResponse<TProjection>>(streamReader.ReadToEnd());
+            var response = JsonConvert.DeserializeObject<CosmosStreamResponse<TProjection>>(streamReader.ReadToEnd(), _jsonSerializerSettings);
 
             return new SearchResponse<TProjection>
             {

--- a/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
+++ b/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
@@ -188,8 +188,8 @@ namespace Spinit.CosmosDb
             {
                 throw new SpinitCosmosDbException(streamResponse.StatusCode, streamResponse.ErrorMessage);
             }
+
             using var streamReader = new StreamReader(streamResponse.Content);
-            using var jsonTextReader = new JsonTextReader(streamReader);
             var response = JsonConvert.DeserializeObject<CosmosStreamResponse<TProjection>>(streamReader.ReadToEnd(), _jsonSerializerSettings);
 
             return new SearchResponse<TProjection>


### PR DESCRIPTION
Serialization seems to be a hard nut to crack :-)
So i noticed that search results are serialized "manually" by this library (not by cosmosclient or documentclient) using Json.Net with default serialization settings. So this PR is a patch to use the same json serializer settings configured for the `CosmosDatabase` in the `CosmosDbCollection` aswell.