### PR TITLE
Add CountAsync to CosmosDbCollection

### DIFF
--- a/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
@@ -43,6 +43,22 @@ namespace Spinit.CosmosDb.FunctionalTests
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
+        public async Task TestCountAll()
+        {
+            var count = await _database.Todos.CountAsync(new SearchRequest<TodoItem> { });
+            Assert.Equal(10, count);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
+        public async Task TestCountWithFilter()
+        {
+            var count = await _database.Todos.CountAsync(new SearchRequest<TodoItem> { Filter = x => x.Status == TodoStatus.Done });
+            Assert.Equal(4, count);
+        }
+
+        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [TestOrder]
         public async Task TestEmptySearch()
         {
             var expectedItemCount = GetTodoItems().Count();

--- a/Spinit.CosmosDb/ICosmosDbCollection.cs
+++ b/Spinit.CosmosDb/ICosmosDbCollection.cs
@@ -67,5 +67,12 @@ namespace Spinit.CosmosDb
         /// <param name="throughput">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
         /// <returns></returns>
         Task SetThroughputAsync(int throughput);
+
+        /// <summary>
+        /// Gets the number of entities.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        Task<int> CountAsync(ISearchRequest<TEntity> request);
     }
 }

--- a/Spinit.CosmosDb/SearchRequest.cs
+++ b/Spinit.CosmosDb/SearchRequest.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 
 namespace Spinit.CosmosDb
 {
-    // TODO: remove TotalCount and eventually replace with a "Count(ISearchRequest request)" call
     public interface ISearchRequest<T>
         where T : class
     {
@@ -11,7 +10,7 @@ namespace Spinit.CosmosDb
 
         int? PageSize { get; }
         /// <summary>
-        /// Should <see cref="SearchResponse{T}.TotalCount"/> be calculated. This is currently a resource heavy operation, use sparingly.
+        /// Should <see cref="SearchResponse{T}.TotalCount"/> be calculated.
         /// </summary>
         bool IncludeTotalCount { get; }
         string ContinuationToken { get; }
@@ -29,7 +28,7 @@ namespace Spinit.CosmosDb
 
         public virtual int? PageSize { get; set; } = 20;
         /// <summary>
-        /// Should <see cref="SearchResponse{T}.TotalCount"/> be calculated. This is currently a resource heavy operation, use sparingly.
+        /// Should <see cref="SearchResponse{T}.TotalCount"/> be calculated.
         /// </summary>
         public virtual bool IncludeTotalCount { get; set; } = false;
         public virtual string ContinuationToken { get; set; }


### PR DESCRIPTION
Adding possibility to get count given a search request. Also removed comments about count being a "resource heavy operation", as this is no longer the case.