### PR TITLE
Replaced int throughput values with ThroughputProperties

### DIFF
--- a/Spinit.CosmosDb.FunctionalTests/CreateDatabaseTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/CreateDatabaseTests.cs
@@ -101,18 +101,23 @@ namespace Spinit.CosmosDb.FunctionalTests
             Assert.Equal(500, throughputProperties.Throughput);
         }
 
-        [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
+        [Theory(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
-        public async Task TestCreateDatabaseWithAutoscaleContainerThroughputSet()
+        [InlineData(1000)]
+        [InlineData(4000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public async Task TestCreateDatabaseWithAutoscaleContainerThroughputSet(int maxThroughput)
         {
             var database = new DummyDatabase();
 
-            await database.Operations.CreateIfNotExistsAsync(new CreateDbOptions(ThroughputProperties.CreateAutoscaleThroughput(4000), ThroughputType.Container));
+            await database.Operations.CreateIfNotExistsAsync(new CreateDbOptions(ThroughputProperties.CreateAutoscaleThroughput(maxThroughput), ThroughputType.Container));
             var throughputProperties = await database.Dummies.GetThroughputAsync();
             await database.Operations.DeleteAsync();
 
-            Assert.Equal(400, throughputProperties.Throughput);
-            Assert.Equal(4000, throughputProperties.AutoscaleMaxThroughput);
+            var minThroughput = maxThroughput / 10;
+            Assert.Equal(minThroughput, throughputProperties.Throughput);
+            Assert.Equal(maxThroughput, throughputProperties.AutoscaleMaxThroughput);
         }
 
         public class DummyDatabase : CosmosDatabase

--- a/Spinit.CosmosDb.FunctionalTests/FunctionTestsConfiguration.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionTestsConfiguration.cs
@@ -2,7 +2,7 @@
 {
     internal static class FunctionTestsConfiguration
     {
-        public const string CosmosDbConnectionString = "";
+        public const string CosmosDbConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
         public const string SkipTests =
 #if DEBUG

--- a/Spinit.CosmosDb.FunctionalTests/FunctionTestsConfiguration.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionTestsConfiguration.cs
@@ -2,7 +2,7 @@
 {
     internal static class FunctionTestsConfiguration
     {
-        public const string CosmosDbConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        public const string CosmosDbConnectionString = "";
 
         public const string SkipTests =
 #if DEBUG

--- a/Spinit.CosmosDb.FunctionalTests/FunctionalCollectionThroughputTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalCollectionThroughputTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 using Spinit.CosmosDb.FunctionalTests.Infrastructure;
 using Xunit;
 
@@ -26,23 +27,23 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         public async Task TestReadCollectionThroughput()
         {
-            var throughput = await _database.Todos.GetThroughputAsync();
-            Assert.Equal(1000, throughput);
+            var throughputProperties = await _database.Todos.GetThroughputAsync();
+            Assert.Equal(1000, throughputProperties.Throughput);
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
         public async Task TestSetDatabaseThroughput()
         {
-            await _database.Todos.SetThroughputAsync(400);
+            await _database.Todos.SetThroughputAsync(ThroughputProperties.CreateManualThroughput(400));
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
         public async Task TestGetDatabaseThroughputAfterSet()
         {
-            var throughput = await _database.Todos.GetThroughputAsync();
-            Assert.Equal(400, throughput);
+            var throughputProperties = await _database.Todos.GetThroughputAsync();
+            Assert.Equal(400, throughputProperties.Throughput);
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]

--- a/Spinit.CosmosDb.FunctionalTests/FunctionalDatabaseThroughputTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalDatabaseThroughputTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 using Spinit.CosmosDb.FunctionalTests.Infrastructure;
 using Xunit;
 
@@ -26,23 +27,23 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         public async Task TestReadDatabaseThroughput()
         {
-            var throughput = await _database.Operations.GetThroughputAsync();
-            Assert.Equal(1000, throughput);
+            var throughputProperties = await _database.Operations.GetThroughputAsync();
+            Assert.Equal(1000, throughputProperties.Throughput);
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
         public async Task TestSetDatabaseThroughput()
         {
-            await _database.Operations.SetThroughputAsync(400);
+            await _database.Operations.SetThroughputAsync(ThroughputProperties.CreateManualThroughput(400));
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
         public async Task TestGetDatabaseThroughputAfterSet()
         {
-            var throughput = await _database.Operations.GetThroughputAsync();
-            Assert.Equal(400, throughput);
+            var throughputProperties = await _database.Operations.GetThroughputAsync();
+            Assert.Equal(400, throughputProperties.Throughput);
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]

--- a/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
+++ b/Spinit.CosmosDb.FunctionalTests/FunctionalTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 using Spinit.CosmosDb.FunctionalTests.Infrastructure;
 using Xunit;
 
@@ -203,7 +204,7 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         public async Task TestReplaceCollectionThroughput()
         {
-            await _database.Todos.SetThroughputAsync(1000);
+            await _database.Todos.SetThroughputAsync(ThroughputProperties.CreateManualThroughput(1000));
         }
 
 
@@ -211,15 +212,15 @@ namespace Spinit.CosmosDb.FunctionalTests
         [TestOrder]
         public async Task TestReadNewlyReplacedThrouhgput()
         {
-            var throughput = await _database.Todos.GetThroughputAsync();
-            Assert.Equal(1000, throughput);
+            var throughputProperties = await _database.Todos.GetThroughputAsync();
+            Assert.Equal(1000, throughputProperties.Throughput);
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]
         [TestOrder]
         public async Task TestReplaceThroughputWithInvalidThroughput()
         {
-            await Assert.ThrowsAsync<ArgumentException>(async () => await _database.Todos.SetThroughputAsync(399));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await _database.Todos.SetThroughputAsync(ThroughputProperties.CreateManualThroughput(399)));
         }
 
         [Fact(Skip = FunctionTestsConfiguration.SkipTests)]

--- a/Spinit.CosmosDb.UnitTests/Validation/ThroughputValidationTests.cs
+++ b/Spinit.CosmosDb.UnitTests/Validation/ThroughputValidationTests.cs
@@ -24,7 +24,7 @@ namespace Spinit.CosmosDb.UnitTests.Validation
         [Theory]
         [InlineData(100, false)]
         [InlineData(400, false)]
-        [InlineData(1000, false)]
+        [InlineData(1000, true)]
         [InlineData(4000, true)]
         [InlineData(10000, true)]
         [InlineData(1000000, true)]

--- a/Spinit.CosmosDb.UnitTests/Validation/ThroughputValidationTests.cs
+++ b/Spinit.CosmosDb.UnitTests/Validation/ThroughputValidationTests.cs
@@ -1,4 +1,5 @@
-﻿using Spinit.CosmosDb.Validation;
+﻿using Microsoft.Azure.Cosmos;
+using Spinit.CosmosDb.Validation;
 using Xunit;
 
 namespace Spinit.CosmosDb.UnitTests.Validation
@@ -14,9 +15,23 @@ namespace Spinit.CosmosDb.UnitTests.Validation
         [InlineData(10000, true)]
         [InlineData(1000000, true)]
         [InlineData(1000001, false)]
-        public void TestIsValidThoughput(int throughput, bool expected)
+        public void TestIsValidManualThoughput(int throughput, bool expected)
         {
-            var isValid = ThroughputValidator.IsValidThroughput(throughput);
+            var isValid = ThroughputValidator.IsValidThroughput(ThroughputProperties.CreateManualThroughput(throughput), out _);
+            Assert.Equal(expected, isValid);
+        }
+
+        [Theory]
+        [InlineData(100, false)]
+        [InlineData(400, false)]
+        [InlineData(1000, false)]
+        [InlineData(4000, true)]
+        [InlineData(10000, true)]
+        [InlineData(1000000, true)]
+        [InlineData(1000001, false)]
+        public void TestIsValidAutoscaleThoughput(int throughput, bool expected)
+        {
+            var isValid = ThroughputValidator.IsValidThroughput(ThroughputProperties.CreateAutoscaleThroughput(throughput), out _);
             Assert.Equal(expected, isValid);
         }
     }

--- a/Spinit.CosmosDb/ICosmosDbCollection.cs
+++ b/Spinit.CosmosDb/ICosmosDbCollection.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 
 namespace Spinit.CosmosDb
 {
@@ -59,14 +60,14 @@ namespace Spinit.CosmosDb
         /// Gets the throughput (RU/s) set for the collection.
         /// </summary>
         /// <returns>The collection's throughput</returns>
-        Task<int?> GetThroughputAsync();
+        Task<ThroughputProperties> GetThroughputAsync();
 
         /// <summary>
         /// Sets the throughput (RU/s) for the collection.
         /// </summary>
-        /// <param name="throughput">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
+        /// <param name="throughputProperties">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
         /// <returns></returns>
-        Task SetThroughputAsync(int throughput);
+        Task SetThroughputAsync(ThroughputProperties throughputProperties);
 
         /// <summary>
         /// Gets the number of entities.

--- a/Spinit.CosmosDb/IDatabaseOperations.cs
+++ b/Spinit.CosmosDb/IDatabaseOperations.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 
 namespace Spinit.CosmosDb
 {
@@ -22,13 +23,13 @@ namespace Spinit.CosmosDb
         /// Gets the throughput (RU/s) set for the collection.
         /// </summary>
         /// <returns></returns>
-        Task<int?> GetThroughputAsync();
+        Task<ThroughputProperties> GetThroughputAsync();
 
         /// <summary>
         /// Sets the throughput (RU/s) for the database.
         /// </summary>
-        /// <param name="throughput">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
+        /// <param name="throughputProperties">The new throughput to set. Must be between 400 and 1000000 in increments of 100.</param>
         /// <returns></returns>
-        Task SetThroughputAsync(int throughput);
+        Task SetThroughputAsync(ThroughputProperties throughputProperties);
     }
 }

--- a/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
+++ b/Spinit.CosmosDb/Internals/CosmosDbCollection.cs
@@ -143,19 +143,19 @@ namespace Spinit.CosmosDb
             return result.Resource;
         }
 
-        public Task<int?> GetThroughputAsync()
+        public async Task<ThroughputProperties> GetThroughputAsync()
         {
-            return _container.ReadThroughputAsync();
+            return await _container.ReadThroughputAsync(new RequestOptions()).ConfigureAwait(false);
         }
 
-        public Task SetThroughputAsync(int throughput)
+        public Task SetThroughputAsync(ThroughputProperties throughputProperties)
         {
-            if (!ThroughputValidator.IsValidThroughput(throughput))
+            if (throughputProperties is { } && !ThroughputValidator.IsValidThroughput(throughputProperties, out var message))
             {
-                throw new ArgumentException("The provided throughput is not valid. Must be between 400 and 1000000 and in increments of 100.", nameof(throughput));
+                throw new ArgumentException(message, nameof(throughputProperties));
             }
 
-            return _container.ReplaceThroughputAsync(throughput);
+            return _container.ReplaceThroughputAsync(throughputProperties);
         }
 
         internal protected virtual async Task<SearchResponse<TProjection>> ExecuteSearchAsync<TProjection>(ISearchRequest<TEntity> request)

--- a/Spinit.CosmosDb/Internals/CreateDbOptions.cs
+++ b/Spinit.CosmosDb/Internals/CreateDbOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Spinit.CosmosDb
+﻿using Microsoft.Azure.Cosmos;
+
+namespace Spinit.CosmosDb
 {
     public class CreateDbOptions
     {
@@ -9,11 +11,22 @@
         /// <param name="throughputType">Where to set the default throughput. Sets the throughput for all containers if Container is selected.</param>
         public CreateDbOptions(int throughput, ThroughputType throughputType)
         {
-            Throughput = throughput;
+            ThroughputProperties = ThroughputProperties.CreateManualThroughput(throughput);
             ThroughputType = throughputType;
         }
 
-        public int Throughput { get; }
+        /// <summary>
+        /// Options for when creating a new database.
+        /// </summary>
+        /// <param name="throughputProperties">The throughput to set.</param>
+        /// <param name="throughputType">Where to set the default throughput. Sets the throughput for all containers if Container is selected.</param>
+        public CreateDbOptions(ThroughputProperties throughputProperties, ThroughputType throughputType)
+        {
+            ThroughputProperties = throughputProperties;
+            ThroughputType = throughputType;
+        }
+
+        public ThroughputProperties ThroughputProperties { get; }
         public ThroughputType ThroughputType { get; }
     }
 }

--- a/Spinit.CosmosDb/Internals/DatabaseOperations.cs
+++ b/Spinit.CosmosDb/Internals/DatabaseOperations.cs
@@ -51,7 +51,7 @@ namespace Spinit.CosmosDb
         /// <summary>
         /// Sets the throughput (RU/s) for the database.
         /// </summary>
-        /// <param name="throughputProperties">The new throughputProeprties to set.
+        /// <param name="throughputProperties">The new throughputProperties to set.</param>
         /// <returns></returns>
         public Task SetThroughputAsync(ThroughputProperties throughputProperties)
         {

--- a/Spinit.CosmosDb/Spinit.CosmosDb.csproj
+++ b/Spinit.CosmosDb/Spinit.CosmosDb.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.26.1" />
     <PackageReference Include="Microsoft.Azure.CosmosDB.BulkExecutor" Version="2.3.0-preview2" /> 
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>

--- a/Spinit.CosmosDb/Validation/ThroughputValidator.cs
+++ b/Spinit.CosmosDb/Validation/ThroughputValidator.cs
@@ -1,7 +1,27 @@
-﻿namespace Spinit.CosmosDb.Validation
+﻿using Microsoft.Azure.Cosmos;
+
+namespace Spinit.CosmosDb.Validation
 {
     internal static class ThroughputValidator
     {
-        internal static bool IsValidThroughput(int throughput) => throughput % 100 == 0 && throughput >= 400 && throughput <= 1000000;
+        internal static bool IsValidManualThroughput(int throughput) => throughput % 100 == 0 && throughput >= 400 && throughput <= 1000000;
+        internal static bool IsValidAutoscaleThroughput(int throughput) => throughput % 1000 == 0 && throughput >= 4000 && throughput <= 1000000;
+
+        internal static bool IsValidThroughput(ThroughputProperties throughputProperties, out string message)
+        {
+            if (throughputProperties.Throughput is int manualThroughput && !IsValidManualThroughput(manualThroughput))
+            {
+                message = "The provided manual throughput is not valid. Must be between 400 and 1000000 and in increments of 100.";
+                return false;
+            }
+            else if(throughputProperties.AutoscaleMaxThroughput is int autoscaleMaxThroughput && !IsValidAutoscaleThroughput(autoscaleMaxThroughput))
+            {
+                message = "The provided autoscale throughput is not valid. Must be between 4000 and 1000000 and in increments of 1000.";
+                return false;
+            }
+
+            message = null;
+            return true;
+        }
     }
 }

--- a/Spinit.CosmosDb/Validation/ThroughputValidator.cs
+++ b/Spinit.CosmosDb/Validation/ThroughputValidator.cs
@@ -4,19 +4,19 @@ namespace Spinit.CosmosDb.Validation
 {
     internal static class ThroughputValidator
     {
-        internal static bool IsValidManualThroughput(int throughput) => throughput % 100 == 0 && throughput >= 400 && throughput <= 1000000;
-        internal static bool IsValidAutoscaleThroughput(int throughput) => throughput % 1000 == 0 && throughput >= 1000 && throughput <= 1000000;
+        internal static bool IsValidManualThroughput(int throughput) => throughput % 100 == 0 && throughput >= 400 && throughput <= 1_000_000;
+        internal static bool IsValidAutoscaleThroughput(int throughput) => throughput % 1000 == 0 && throughput >= 1000 && throughput <= 1_000_000;
 
         internal static bool IsValidThroughput(ThroughputProperties throughputProperties, out string message)
         {
             if (throughputProperties.Throughput is int manualThroughput && !IsValidManualThroughput(manualThroughput))
             {
-                message = "The provided manual throughput is not valid. Must be between 400 and 1000000 and in increments of 100.";
+                message = "The provided manual throughput is not valid. Must be between 400 and 1 000 000 and in increments of 100.";
                 return false;
             }
             else if(throughputProperties.AutoscaleMaxThroughput is int autoscaleMaxThroughput && !IsValidAutoscaleThroughput(autoscaleMaxThroughput))
             {
-                message = "The provided autoscale throughput is not valid. Must be between 4000 and 1000000 and in increments of 1000.";
+                message = "The provided autoscale throughput is not valid. Must be between 4000 and 1 000 000 and in increments of 1 000.";
                 return false;
             }
 

--- a/Spinit.CosmosDb/Validation/ThroughputValidator.cs
+++ b/Spinit.CosmosDb/Validation/ThroughputValidator.cs
@@ -16,7 +16,7 @@ namespace Spinit.CosmosDb.Validation
             }
             else if(throughputProperties.AutoscaleMaxThroughput is int autoscaleMaxThroughput && !IsValidAutoscaleThroughput(autoscaleMaxThroughput))
             {
-                message = "The provided autoscale throughput is not valid. Must be between 4000 and 1 000 000 and in increments of 1 000.";
+                message = "The provided autoscale throughput is not valid. Must be between 1 000 and 1 000 000 and in increments of 1 000.";
                 return false;
             }
 

--- a/Spinit.CosmosDb/Validation/ThroughputValidator.cs
+++ b/Spinit.CosmosDb/Validation/ThroughputValidator.cs
@@ -5,7 +5,7 @@ namespace Spinit.CosmosDb.Validation
     internal static class ThroughputValidator
     {
         internal static bool IsValidManualThroughput(int throughput) => throughput % 100 == 0 && throughput >= 400 && throughput <= 1000000;
-        internal static bool IsValidAutoscaleThroughput(int throughput) => throughput % 1000 == 0 && throughput >= 4000 && throughput <= 1000000;
+        internal static bool IsValidAutoscaleThroughput(int throughput) => throughput % 1000 == 0 && throughput >= 1000 && throughput <= 1000000;
 
         internal static bool IsValidThroughput(ThroughputProperties throughputProperties, out string message)
         {


### PR DESCRIPTION
This enables setting autoscale throughput programmatically.
This might be a breaking change though, since we're changing the api